### PR TITLE
feat: Update app scripts and log response in register component

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng dev",
+    "dev": "ng dev",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/src/app/auth/component/register/register.component.ts
+++ b/src/app/auth/component/register/register.component.ts
@@ -49,6 +49,6 @@ export class RegisterComponent {
     this.store.dispatch(authActions.register({ request }));
     this.authService
       .register(request)
-      .subscribe((res) => console.log('res=' + res));
+      .subscribe((res) => console.log('res=' + JSON.stringify(res)));
   }
 }

--- a/src/app/auth/store/effects.ts
+++ b/src/app/auth/store/effects.ts
@@ -1,18 +1,25 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, map, of, switchMap, tap } from 'rxjs';
+import { PersistanceService } from '../../shared/services/persistance.service';
 import { AuthService } from '../services/auth.service';
 import { CurrentUserInterface } from './../../shared/types/currentUser.interface';
 import { authActions } from './actions';
 
 export const registerEffect = createEffect(
-  (actions$ = inject(Actions), authService = inject(AuthService)) => {
+  (
+    actions$ = inject(Actions),
+    authService = inject(AuthService),
+    persistanceService = inject(PersistanceService)
+  ) => {
     return actions$.pipe(
       ofType(authActions.register),
       switchMap(({ request }) => {
         return authService.register(request).pipe(
           map((currentUser: CurrentUserInterface) => {
+            persistanceService.set('accessToken', currentUser.token);
             return authActions.registerSuccess({ currentUser });
           }),
           catchError((errorResponse: HttpErrorResponse) => {
@@ -27,4 +34,19 @@ export const registerEffect = createEffect(
     );
   },
   { functional: true }
+);
+
+export const redirectAfterRegisterEffect = createEffect(
+  (actions$ = inject(Actions), router = inject(Router)) => {
+    return actions$.pipe(
+      ofType(authActions.registerSuccess),
+      tap(() => {
+        router.navigateByUrl('/');
+      })
+    );
+  },
+  {
+    functional: true,
+    dispatch: false,
+  }
 );

--- a/src/app/shared/components/backend-error-messages/backend-error-messages.component.ts
+++ b/src/app/shared/components/backend-error-messages/backend-error-messages.component.ts
@@ -6,7 +6,6 @@ import { BackendErrorsInterface } from '../../types/backendError.interface';
   standalone: true,
   imports: [],
   templateUrl: './backend-error-messages.component.html',
-  styleUrl: './backend-error-messages.component.scss',
 })
 export class BackendErrorMessagesComponent implements OnInit {
   backendErrors = input.required<BackendErrorsInterface>();

--- a/src/app/shared/services/persistance.service.ts
+++ b/src/app/shared/services/persistance.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PersistanceService {
+  set(key: string, data: unknown): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(data));
+    } catch (error) {
+      console.error('Error while saving to local storage ', error);
+    }
+  }
+  get(key: string): unknown {
+    try {
+      const localStorageItem = localStorage.getItem(key);
+      return localStorageItem ? JSON.parse(localStorageItem) : null;
+    } catch (error) {
+      console.error('Error while getting data from local storage ', error);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
- Update the `start` script to `dev` in the `package.json` file to better
  reflect the purpose of the script.
- Update the `subscribe` callback in the `register` method of the
  `RegisterComponent` to log the response as a JSON string instead of a
  simple string. This will provide more detailed information about the
  registration response.