### PR TITLE
feat(auth): Add getCurrentUserEffect and update actions

### DIFF
--- a/src/app/auth/store/actions.ts
+++ b/src/app/auth/store/actions.ts
@@ -1,4 +1,4 @@
-import { createActionGroup, props } from '@ngrx/store';
+import { createActionGroup, emptyProps, props } from '@ngrx/store';
 import { CurrentUserInterface } from '../../shared/types/currentUser.interface';
 import { LoginRequestInterface } from '../types/loginRequest.interface';
 import { RegisterRequestInterface } from '../types/registerRequest.interface';
@@ -14,5 +14,9 @@ export const authActions = createActionGroup({
     Login: props<{ request: LoginRequestInterface }>(),
     'Login success': props<{ currentUser: CurrentUserInterface }>(),
     'Login failure': props<{ errors: BackendErrorsInterface }>(),
+
+    'Get current user': emptyProps(),
+    'Get current user success': props<{ currentUser: CurrentUserInterface }>(),
+    'Get current user failure': emptyProps(),
   },
 });

--- a/src/app/auth/store/effects.ts
+++ b/src/app/auth/store/effects.ts
@@ -8,6 +8,30 @@ import { AuthService } from '../services/auth.service';
 import { CurrentUserInterface } from './../../shared/types/currentUser.interface';
 import { authActions } from './actions';
 
+export const getCurrentUserEffect = createEffect(
+  (
+    actions$ = inject(Actions),
+    authService = inject(AuthService),
+    persistanceService = inject(PersistanceService)
+  ) => {
+    return actions$.pipe(
+      ofType(authActions.getCurrentUser),
+      switchMap(() => {
+        return authService.getCurrentUser().pipe(
+          map((currentUser: CurrentUserInterface) => {
+            persistanceService.get('accessToken');
+            return authActions.getCurrentUserSuccess({ currentUser });
+          }),
+          catchError(() => {
+            return of(authActions.getCurrentUserFailure());
+          })
+        );
+      })
+    );
+  },
+  { functional: true }
+);
+
 export const registerEffect = createEffect(
   (
     actions$ = inject(Actions),


### PR DESCRIPTION
Adds a new `getCurrentUserEffect` to fetch the current user from the
server and store the response in the state. Also updates the `authActions`
to include new actions for getting the current user.

These changes are necessary to implement the functionality of fetching
the current user when the application loads, which is a core part of
the authentication flow.